### PR TITLE
Simplify dashboard header

### DIFF
--- a/client/src/components/dashboard-header.tsx
+++ b/client/src/components/dashboard-header.tsx
@@ -1,50 +1,19 @@
-import { formatDistanceToNow, parseISO } from "date-fns";
-
-interface DashboardHeaderProps {
-  lastUpdated: string;
-  isConnected: boolean;
-}
-
-export default function DashboardHeader({ lastUpdated, isConnected }: DashboardHeaderProps) {
-  const formatLastUpdated = (timestamp: string) => {
-    if (timestamp === 'Never' || timestamp === 'Loading...' || timestamp === 'Error occurred') {
-      return timestamp;
-    }
-    
-    try {
-      return formatDistanceToNow(parseISO(timestamp), { addSuffix: true });
-    } catch {
-      return 'Unknown';
-    }
-  };
-
+export default function DashboardHeader() {
   return (
     <header className="bg-card border-b border-border shadow-sm">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center justify-between h-16">
+        <div className="flex items-center h-16">
           <div className="flex items-center space-x-3">
             <div className="bg-primary p-2 rounded-lg">
               <svg className="w-6 h-6 text-primary-foreground" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M12 2L2 7v10c0 5.55 3.84 9.739 9 11 5.16-1.261 9-5.45 9-11V7l-10-5z"/>
+                <path d="M12 2L2 7v10c0 5.55 3.84 9.739 9 11 5.16-1.261 9-5.45 9-11V7l-10-5z" />
               </svg>
             </div>
-            <div>
-              <h1 className="text-xl font-semibold text-foreground">Waze Incidents Dashboard</h1>
-              <p className="text-sm text-muted-foreground">Warsaw Area Monitoring</p>
-            </div>
-          </div>
-          
-          <div className="flex items-center space-x-4">
-            <div className="flex items-center space-x-2" data-testid="connection-status">
-              <div className={`w-2 h-2 rounded-full ${isConnected ? 'bg-green-500 animate-pulse' : 'bg-red-500'}`}></div>
-              <span className="text-sm text-muted-foreground">{isConnected ? 'Live' : 'Offline'}</span>
-            </div>
-            <div className="text-sm text-muted-foreground" data-testid="text-last-updated">
-              Last updated: <span>{formatLastUpdated(lastUpdated)}</span>
-            </div>
+            <h1 className="text-xl font-semibold text-foreground">AutoWola Dashboard</h1>
           </div>
         </div>
       </div>
     </header>
   );
 }
+

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -55,10 +55,7 @@ export default function Dashboard() {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-background">
-        <DashboardHeader 
-          lastUpdated="Loading..."
-          isConnected={false}
-        />
+        <DashboardHeader />
         <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
           <div className="flex items-center justify-center py-12">
             <div className="bg-card rounded-lg p-6 shadow-sm border border-border">
@@ -76,10 +73,7 @@ export default function Dashboard() {
   if (error) {
     return (
       <div className="min-h-screen bg-background">
-        <DashboardHeader 
-          lastUpdated="Error occurred"
-          isConnected={false}
-        />
+        <DashboardHeader />
         <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
           <Card className="border-destructive/20 bg-destructive/5 mb-6">
             <CardContent className="pt-6">
@@ -112,10 +106,7 @@ export default function Dashboard() {
 
   return (
     <div className="min-h-screen bg-background">
-      <DashboardHeader 
-        lastUpdated={data?.stats.lastUpdated || 'Never'}
-        isConnected={data?.stats.apiStatus === 'Online'}
-      />
+      <DashboardHeader />
       
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
         {data?.stats && (


### PR DESCRIPTION
## Summary
- replace dashboard heading with "AutoWola Dashboard"
- remove connection status and last updated text from header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Type 'string | null | undefined' is not assignable to type 'string | null' in server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b73e6ca184832ab7e619f9e442dd90