### PR TITLE
feat: add logo header with refresh timer

### DIFF
--- a/client/src/components/dashboard-header.tsx
+++ b/client/src/components/dashboard-header.tsx
@@ -1,16 +1,29 @@
+import { useEffect, useState } from "react";
+
 export default function DashboardHeader() {
+  const REFRESH_INTERVAL = 15;
+  const [refreshIn, setRefreshIn] = useState(REFRESH_INTERVAL);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setRefreshIn(prev => (prev <= 1 ? REFRESH_INTERVAL : prev - 1));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
   return (
     <header className="bg-card border-b border-border shadow-sm">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center h-16">
+        <div className="flex items-center justify-between h-16">
           <div className="flex items-center space-x-3">
-            <div className="bg-primary p-2 rounded-lg">
-              <svg className="w-6 h-6 text-primary-foreground" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M12 2L2 7v10c0 5.55 3.84 9.739 9 11 5.16-1.261 9-5.45 9-11V7l-10-5z" />
-              </svg>
-            </div>
-            <h1 className="text-xl font-semibold text-foreground">AutoWola Dashboard</h1>
+            <img
+              src="https://autowola.com/wp-content/uploads/2025/08/Logo.svg"
+              alt="AutoWola logo"
+              className="h-8 w-auto"
+            />
+            <h1 className="text-xl font-semibold text-foreground">Dashboard</h1>
           </div>
+          <div className="text-sm text-muted-foreground">Refresh in: {refreshIn}s</div>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- replace placeholder icon with AutoWola logo and Dashboard title
- add countdown timer showing seconds until next refresh

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: Type 'string | null | undefined' is not assignable to type 'string | null')


------
https://chatgpt.com/codex/tasks/task_e_68b74990736c832a9642b491548fd37f