### PR TITLE
Expand Waze API coverage to nine tiles

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -61,14 +61,19 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
 async function fetchWazeIncidents(): Promise<WazeApiResponse> {
   const urls = [
-    "https://www.waze.com/live-map/api/georss?bottom=52.1397&left=20.8662&top=52.2297&right=21.0122&env=row&types=alerts",
-    "https://www.waze.com/live-map/api/georss?bottom=52.1397&left=21.0122&top=52.2297&right=21.1582&env=row&types=alerts",
-    "https://www.waze.com/live-map/api/georss?bottom=52.2297&left=20.8662&top=52.3197&right=21.0122&env=row&types=alerts",
-    "https://www.waze.com/live-map/api/georss?bottom=52.2297&left=21.0122&top=52.3197&right=21.1582&env=row&types=alerts"
+    "https://www.waze.com/live-map/api/georss?bottom=52.050000&left=20.750000&top=52.166667&right=20.916667&env=row&types=alerts",
+    "https://www.waze.com/live-map/api/georss?bottom=52.050000&left=20.916667&top=52.166667&right=21.083333&env=row&types=alerts",
+    "https://www.waze.com/live-map/api/georss?bottom=52.050000&left=21.083333&top=52.166667&right=21.250000&env=row&types=alerts",
+    "https://www.waze.com/live-map/api/georss?bottom=52.166667&left=20.750000&top=52.283333&right=20.916667&env=row&types=alerts",
+    "https://www.waze.com/live-map/api/georss?bottom=52.166667&left=20.916667&top=52.283333&right=21.083333&env=row&types=alerts",
+    "https://www.waze.com/live-map/api/georss?bottom=52.166667&left=21.083333&top=52.283333&right=21.250000&env=row&types=alerts",
+    "https://www.waze.com/live-map/api/georss?bottom=52.283333&left=20.750000&top=52.400000&right=20.916667&env=row&types=alerts",
+    "https://www.waze.com/live-map/api/georss?bottom=52.283333&left=20.916667&top=52.400000&right=21.083333&env=row&types=alerts",
+    "https://www.waze.com/live-map/api/georss?bottom=52.283333&left=21.083333&top=52.400000&right=21.250000&env=row&types=alerts"
   ];
   
   try {
-    // Make all 4 requests in parallel
+    // Make all 9 requests in parallel
     const promises = urls.map(url => fetchSingleWazeArea(url));
     const results = await Promise.allSettled(promises);
     

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -50,6 +50,13 @@ export class MemStorage implements IStorage {
   async upsertIncident(insertIncident: InsertIncident): Promise<Incident> {
     const incident: Incident = {
       ...insertIncident,
+      status: insertIncident.status ?? null,
+      description: insertIncident.description ?? null,
+      severity: insertIncident.severity ?? null,
+      reliability: insertIncident.reliability ?? null,
+      reporter: insertIncident.reporter ?? null,
+      rating: insertIncident.rating ?? null,
+      confidence: insertIncident.confidence ?? null,
       lastUpdated: new Date(),
     };
     this.incidents.set(incident.id, incident);


### PR DESCRIPTION
## Summary
- replace 4 Waze GeoRSS queries with 9 updated tiles to widen alert coverage
- ensure in-memory storage fills optional incident fields with defaults to satisfy type checking

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b895c09ce0832a98c61360e9d5c082